### PR TITLE
Better Tutorial Radio Handling

### DIFF
--- a/_std/defines/speech_defines/modules.dm
+++ b/_std/defines/speech_defines/modules.dm
@@ -232,6 +232,7 @@
 #define LISTEN_EFFECT_PARROT "parrot"
 #define LISTEN_EFFECT_PROTOTYPE_MAPTEXT "prototype_maptext"
 #define LISTEN_EFFECT_RADIO "radio"
+#define LISTEN_EFFECT_RADIO_TUTORIAL "tutorial_radio"
 #define LISTEN_EFFECT_RITUAL "ritual"
 #define LISTEN_EFFECT_SIMS_SOCIAL_MOTIVE "sims_social_motive"
 #define LISTEN_EFFECT_SKULLBOT "skullbot"

--- a/code/modules/tutorials/newbee/tutorial_obj.dm
+++ b/code/modules/tutorials/newbee/tutorial_obj.dm
@@ -282,49 +282,16 @@
 		else
 			D.setMaterial(getMaterial("steel"))
 
+TYPEINFO(/obj/item/device/radio/headset/tutorial)
+	start_listen_effects = list(LISTEN_EFFECT_RADIO_TUTORIAL)
+
 /obj/item/device/radio/headset/tutorial
 	hardened = TRUE // needs to always work
-	protected_radio = TRUE
 	locked_frequency = TRUE
 
-	var/radio_freq_alpha
-	var/radio_freq_beta
+/obj/item/device/radio/headset/tutorial/receive_signal()
+	return
 
-/obj/item/device/radio/headset/tutorial/New()
-	. = ..()
-	src.radio_freq_alpha = src.pick_randomized_freq()
-	global.protected_frequencies += src.radio_freq_alpha
-
-	src.radio_freq_beta = src.pick_randomized_freq()
-	global.protected_frequencies += src.radio_freq_beta
-
-	src.bricked = FALSE // always. work.
-
-	src.secure_frequencies = list(
-		"a" = src.radio_freq_alpha,
-		"b" = src.radio_freq_beta,
-	)
-	src.secure_classes = list(
-		"a" = RADIOCL_ENGINEERING,
-		"b" = RADIOCL_RESEARCH,
-	)
-
-	src.set_secure_frequencies()
-	src.frequency = src.radio_freq_alpha
-
-/obj/item/device/radio/headset/tutorial/proc/pick_randomized_freq()
-	var/list/blacklisted = list(FREQ_SIGNALER)
-	blacklisted.Add(R_FREQ_BLACKLIST)
-	blacklisted += global.protected_frequencies
-
-	do
-		. = rand(1352, 1439)
-	while (blacklisted.Find(.))
-
-/obj/item/device/radio/headset/tutorial/disposing()
-	. = ..()
-	global.protected_frequencies -= src.radio_freq_alpha
-	global.protected_frequencies -= src.radio_freq_beta
 
 /obj/health_scanner/floor/tutorial
 	crit_alert(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The PR:
Reworks the tutorial headset to directly route its own messages to itself and prevents it from receiving external packets. This allows the packet network to be circumvented entirely, so that no external factors (storms, packet blockers, etc) may interfere with tutorial radios.

As a result, the headset can now use the ordinary radio channels without worry that the newbee will receive the crew's messages, or the crew will receive theirs.
